### PR TITLE
add 'graceful-fs' lib

### DIFF
--- a/__tests__/archiverUtils.test.ts
+++ b/__tests__/archiverUtils.test.ts
@@ -4,7 +4,7 @@
  * "Sonatype" is a trademark of Sonatype, Inc.
  */
 
-import * as fs from 'fs';
+import * as fs from 'graceful-fs';
 import * as rimraf from 'rimraf';
 import * as path from 'path';
 import {ArchiveUtils} from '../src/archiveUtils';

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -5,7 +5,7 @@
  */
 
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'graceful-fs';
 import * as rimraf from 'rimraf';
 import {findFiles} from '../src/scanPattern';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -473,6 +473,15 @@
         "@types/node": "*"
       }
     },
+    "@types/graceful-fs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+      "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "@actions/core": "1.2.0",
     "archiver": "3.1.1",
     "email-validator": "2.0.4",
-    "glob": "7.1.5"
+    "glob": "7.1.5",
+    "graceful-fs": "4.2.3"
   },
   "devDependencies": {
     "@types/archiver": "3.0.0",
     "@types/glob": "7.1.1",
+    "@types/graceful-fs": "4.1.3",
     "@types/jest": "24.0.20",
     "@types/node": "12.11.7",
     "@types/rimraf": "2.0.3",

--- a/src/archiveUtils.ts
+++ b/src/archiveUtils.ts
@@ -5,7 +5,7 @@
  */
 
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'graceful-fs';
 import Archiver = require('archiver');
 import config from './config.json';
 

--- a/src/fileUploadService.ts
+++ b/src/fileUploadService.ts
@@ -5,7 +5,7 @@
  */
 
 import * as http from 'http';
-import * as fs from 'fs';
+import * as fs from 'graceful-fs';
 import * as https from 'https';
 import HashUtils from './hashUtils';
 import config from './config.json';


### PR DESCRIPTION
#### Description
For **NodeJs** project with a lot of files in _node_modules_ dir while running **GitHub Actions** could be thrown the error: 
`EMFILE, too many open files`
The **graceful-fs** lib resolves that issue.
